### PR TITLE
Support GxEPD2 7.3" 7‑color display

### DIFF
--- a/include/GxEPD2_display_selection_new_style.h
+++ b/include/GxEPD2_display_selection_new_style.h
@@ -19,9 +19,9 @@
 
 // select the display class (only one), matching the kind of display panel
 //#define GxEPD2_DISPLAY_CLASS GxEPD2_BW
-#define GxEPD2_DISPLAY_CLASS GxEPD2_3C
+//#define GxEPD2_DISPLAY_CLASS GxEPD2_3C
 //#define GxEPD2_DISPLAY_CLASS GxEPD2_4C
-//#define GxEPD2_DISPLAY_CLASS GxEPD2_7C
+#define GxEPD2_DISPLAY_CLASS GxEPD2_7C
 
 // 脚本编译需要，根据命令行参数编译不同版本固件。
 #if defined(SI_DRIVER)
@@ -31,6 +31,8 @@
         #define GxEPD2_DRIVER_CLASS GxEPD2_420c_Z21
     #elif (SI_DRIVER == 98)
         #define GxEPD2_DRIVER_CLASS GxEPD2_420c_GDEY042Z98
+    #elif (SI_DRIVER == 730)
+        #define GxEPD2_DRIVER_CLASS GxEPD2_730c_GDEY073D46
     #endif
 #endif
 
@@ -38,7 +40,7 @@
 #ifndef GxEPD2_DRIVER_CLASS
 // #define GxEPD2_DRIVER_CLASS GxEPD2_420c // Z15
 // #define GxEPD2_DRIVER_CLASS GxEPD2_420c_Z21 // Z21
-#define GxEPD2_DRIVER_CLASS GxEPD2_420c_GDEY042Z98 // Z98
+#define GxEPD2_DRIVER_CLASS GxEPD2_730c_GDEY073D46
 #endif
 
 // select the display driver class (only one) for your  panel

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,8 @@
 
 [platformio]
 description = Ink Screen Calendar
-default_envs = 
-	z21
+default_envs =
+        d46
 
 [common]
 framework = arduino
@@ -59,7 +59,19 @@ upload_speed = 460800
 monitor_speed = 115200
 board_build.partitions = min_spiffs.csv
 build_flags =
-	-D SI_DRIVER=15
+        -D SI_DRIVER=15
+
+[env:d46]
+build_type = release
+platform = espressif32
+board = esp32dev
+framework = ${common.framework}
+lib_deps = ${common.lib_deps}
+upload_speed = 460800
+monitor_speed = 115200
+board_build.partitions = min_spiffs.csv
+build_flags =
+        -D SI_DRIVER=730
 
 [env:esp32c3]
 platform = espressif32


### PR DESCRIPTION
## Summary
- switch display driver class to 7-color
- add compile option for SI_DRIVER=730
- set new default environment `d46`

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d2a6253a8833189a7f2801fcf5c38